### PR TITLE
Error tipógrafico 

### DIFF
--- a/README_es.md
+++ b/README_es.md
@@ -1,4 +1,4 @@
-# Simple terminal (st) de gerardet45
+# Simple terminal (st) de gerardet46
 
 Esta es mi versión configurada de [simple terminal](https://st.suckless.org/), de suckless. Está inspirado en la configuración de [luke
 smith](https://github.com/lukesmithxyz/st) pero se ha creado a partir de la versión 0.8.4 oficial a suckless.org, añadiendo los parches que encontraba necesarios.


### PR DESCRIPTION
En el README_es.md creo que había un error tipógrafico. En lugar de 'gerardet45' debía ser 'gerardet46' , supongo.

Salut!